### PR TITLE
Updated inquirer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "email": "chrisenytc@gmail.com",
         "url": "https://github.com/chrisenytc"
     },
-	"license": "MIT",
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "git://github.com/chrisenytc/slush-generator.git"
@@ -32,7 +32,7 @@
         "gulp-conflict": "~0.1.1",
         "gulp-rename": "~1.2.0",
         "underscore.string": "~2.3.3",
-        "inquirer": "~0.8.0",
+        "inquirer": "~3.3.0",
         "iniparser": "^1.0.5"
     },
     "devDependencies": {

--- a/slushfile.js
+++ b/slushfile.js
@@ -91,8 +91,9 @@ gulp.task('default', function (done) {
         message: 'Continue?'
     }];
     //Ask
-    inquirer.prompt(prompts,
-        function (answers) {
+    inquirer
+        .prompt(prompts)
+        .then(function (answers) {
             if (!answers.moveon) {
                 return done();
             }

--- a/templates/package.json
+++ b/templates/package.json
@@ -31,7 +31,7 @@
         "gulp-conflict": "^0.1.1",
         "gulp-rename": "^1.2.0",
         "underscore.string": "^2.3.3",
-        "inquirer": "^0.8.0",
+        "inquirer": "^3.3.0",
         "iniparser": "^1.0.5"
     },
     "keywords": [

--- a/templates/slushfile.js
+++ b/templates/slushfile.js
@@ -80,8 +80,9 @@ gulp.task('default', function (done) {
         message: 'Continue?'
     }];
     //Ask
-    inquirer.prompt(prompts,
-        function (answers) {
+    inquirer
+        .prompt(prompts)
+        .then(function (answers) {
             if (!answers.moveon) {
                 return done();
             }


### PR DESCRIPTION
The version of inquirer is too old, we should update it, so that user can use the new inquirer.

I was trying to use the latest inquirer to write my own release script, but then realized that an older version of inquirer was installed, and the new syntax won't work.

After this fix, user should be able to use the latest inquirer.